### PR TITLE
build libskia.so with its own build toolchain

### DIFF
--- a/build_skia.sh
+++ b/build_skia.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Run this script as `source ./build_skia.sh`.
+# This way the LD_LIBRARY_PATH environment variable is imported in the current shell.
+# NOTE: This was only tested on macOS. It requires python2 to be on the $PATH and
+# it must be run *outside* of a python3 venv otherwise gn tool will complain...
+
+pushd src/cpp/skia
+
+python2 tools/git-sync-deps
+
+bin/gn gen out/Shared --args='is_official_build=true is_component_build=true is_debug=false skia_enable_pdf=false skia_enable_ccpr=false skia_enable_gpu=false skia_enable_discrete_gpu=false skia_enable_nvpr=false skia_enable_skottie=false skia_enable_skshaper=false skia_use_dng_sdk=false skia_use_expat=false skia_use_gl=false skia_use_harfbuzz=false skia_use_icu=false skia_use_libgifcodec=false skia_use_libjpeg_turbo=false skia_use_libwebp=false skia_use_piex=false skia_use_sfntly=false skia_use_xps=false skia_use_zlib=false skia_use_libpng=false'
+
+ninja -C out/Shared
+
+export LD_LIBRARY_PATH=$(pwd)/out/Shared
+
+popd

--- a/setup.py
+++ b/setup.py
@@ -390,6 +390,8 @@ extensions = [
         define_macros=define_macros,
         include_dirs=include_dirs,
         extra_compile_args=extra_compile_args,
+        libraries=["skia"],
+        library_dirs=["src/cpp/skia/out/Shared"],
         language="c++",
     ),
 ]
@@ -411,7 +413,7 @@ setup_params = dict(
     license="BSD-3-Clause",
     package_dir={"": pkg_dir},
     packages=find_packages(pkg_dir),
-    libraries=libraries,
+    # libraries=libraries,
     ext_modules=extensions,
     cmdclass={
         'build_ext': custom_build_ext,

--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -337,7 +337,7 @@ cdef class Path:
     cpdef stroke(self, width):
         stroke_rec = new SkStrokeRec(kFill_InitStyle)
         try:
-             stroke_rec.setStrokeStyle(width)
+             stroke_rec.setStrokeStyle(width, False)
              stroke_rec.applyToPath(&self.path, self.path)
         finally:
             del stroke_rec

--- a/src/python/pathops/_skia/core.pxd
+++ b/src/python/pathops/_skia/core.pxd
@@ -154,7 +154,7 @@ cdef extern from "include/core/SkStrokeRec.h":
     cdef cppclass SkStrokeRec:
         SkStrokeRec(InitStyle style)
 
-        void setStrokeStyle(SkScalar width, bint strokeAndFill = false)
+        void setStrokeStyle(SkScalar width, bint strokeAndFill)
 
         bint applyToPath(SkPath* dst, const SkPath& src) const;
 


### PR DESCRIPTION
Only tested on mac.
The semi-manual workflow is this:

```
$ source ./build_skia.sh
$ python setup.py build_ext --inplace
```