### PR TITLE
expose svg-like SkPath::arcTo method as Path.arcTo()

### DIFF
--- a/src/python/pathops/__init__.py
+++ b/src/python/pathops/__init__.py
@@ -6,6 +6,8 @@ from ._pathops import (
     FillType,
     LineCap,
     LineJoin,
+    ArcSize,
+    Direction,
     op,
     simplify,
     OpBuilder,

--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -12,6 +12,9 @@ from ._skia.core cimport (
     kCubic_Verb,
     kClose_Verb,
     kDone_Verb,
+    kSmall_ArcSize,
+    kLarge_ArcSize,
+    SkPathDirection,
 )
 from ._skia.pathops cimport (
     SkOpBuilder,
@@ -49,6 +52,16 @@ cpdef enum LineJoin:
     MITER_JOIN = <uint32_t>SkLineJoin.kMiter_Join,
     ROUND_JOIN = <uint32_t>SkLineJoin.kRound_Join,
     BEVEL_JOIN = <uint32_t>SkLineJoin.kBevel_Join
+
+
+cpdef enum ArcSize:
+    SMALL = kSmall_ArcSize
+    LARGE = kLarge_ArcSize
+
+
+cpdef enum Direction:
+    CW = <uint32_t>SkPathDirection.kCW
+    CCW = <uint32_t>SkPathDirection.kCCW
 
 
 cdef union FloatIntUnion:
@@ -119,6 +132,17 @@ cdef class Path:
         SkScalar y2,
         SkScalar x3,
         SkScalar y3,
+    )
+
+    cpdef void arcTo(
+        self,
+        SkScalar rx,
+        SkScalar ry,
+        SkScalar xAxisRotate,
+        ArcSize largeArc,
+        Direction sweep,
+        SkScalar x,
+        SkScalar y,
     )
 
     cpdef void close(self)

--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -7,6 +7,7 @@ from ._skia.core cimport (
     SkRect,
     SkLineCap,
     SkLineJoin,
+    SkPathDirection,
     kMove_Verb,
     kLine_Verb,
     kQuad_Verb,
@@ -209,6 +210,18 @@ cdef class Path:
         SkScalar y3,
     ):
         self.path.cubicTo(x1, y1, x2, y2, x3, y3)
+
+    cpdef void arcTo(
+        self,
+        SkScalar rx,
+        SkScalar ry,
+        SkScalar xAxisRotate,
+        ArcSize largeArc,
+        Direction sweep,
+        SkScalar x,
+        SkScalar y,
+    ):
+        self.path.arcTo(rx, ry, xAxisRotate, largeArc, <SkPathDirection>sweep, x, y)
 
     cpdef void close(self):
         self.path.close()

--- a/src/python/pathops/_skia/core.pxd
+++ b/src/python/pathops/_skia/core.pxd
@@ -12,6 +12,10 @@ cdef extern from "include/core/SkPathTypes.h":
         kInverseWinding "SkPathFillType::kInverseWinding",
         kInverseEvenOdd "SkPathFillType::kInverseEvenOdd"
 
+    enum SkPathDirection:
+        kCW "SkPathDirection::kCW"
+        kCCW "SkPathDirection::kCCW"
+
 
 cdef extern from "include/core/SkPath.h":
 
@@ -56,6 +60,11 @@ cdef extern from "include/core/SkPath.h":
         void conicTo(SkScalar x1, SkScalar y1, SkScalar x2, SkScalar y2,
                      SkScalar w)
         void conicTo(const SkPoint& p1, const SkPoint& p2, SkScalar w)
+
+        void arcTo(SkScalar rx, SkScalar ry, SkScalar xAxisRotate, ArcSize largeArc,
+                   SkPathDirection sweep, SkScalar x, SkScalar y)
+        void arcTo(SkPoint& r, SkScalar xAxisRotate, ArcSize largeArc,
+                   SkPathDirection sweep, SkPoint& xy)
 
         void close()
 
@@ -134,6 +143,10 @@ cdef extern from * namespace "SkPath":
     cdef int ConvertConicToQuads(const SkPoint& p0, const SkPoint& p1,
                                  const SkPoint& p2, SkScalar w,
                                  SkPoint pts[], int pow2)
+
+    enum ArcSize:
+        kSmall_ArcSize
+        kLarge_ArcSize
 
 
 cdef extern from "include/core/SkRect.h":

--- a/tests/pathops_test.py
+++ b/tests/pathops_test.py
@@ -8,6 +8,8 @@ from pathops import (
     FillType,
     bits2float,
     float2bits,
+    ArcSize,
+    Direction,
 )
 
 import pytest
@@ -723,6 +725,31 @@ def test_strip_collinear_moveTo():
                 ('endPath', ())
             ),
         ),
+        (
+            'arc_to_quads',
+            (
+                ('moveTo', (7, 5)),
+                ('arcTo', (3, 1, 0, ArcSize.SMALL, Direction.CCW, 7, 2)),
+                ('convertConicsToQuads', ()),
+            ),
+            (
+                ('moveTo', ((7.0, 5.0),)),
+                (
+                    'qCurveTo', (
+                        (7.9, 5.0),
+                        (9.55, 4.77),
+                        (10.81, 4.35),
+                        (11.5, 3.8),
+                        (11.5, 3.2),
+                        (10.81, 2.65),
+                        (9.55, 2.23),
+                        (7.9, 2.0),
+                        (7.0, 2.0)
+                    )
+                ),
+                ('endPath', ()),
+            )
+        )
     ]
 )
 def test_path_operation(message, operations, expected):


### PR DESCRIPTION
https://skia.org/user/api/SkPath_Reference#SkPath_arcTo

The SkPath::arcTo method implements the functionality of SVG arcs. The only difference is that
the SVG 'sweep-flag' value is opposite the integer value of 'sweep' argument in SkPath::arcTo.
That is, SVG 'sweep-flag' uses 1 for clockwise, whereas SkPathDirection::kCW cast to int is 0.

So in nanosvg, if we want to use this to draw SVG arc commands onto a pathops.Path, we need to
make sure that we negate the sweep flag.

